### PR TITLE
add v4.1 token endpoints

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -308,4 +308,42 @@ class UserModel extends AbstractModel
     {
         return $this->client->post(self::$endpoint . '/login/switch', $requestOptions);
     }
+
+    /**
+     * @param $userId
+     * @param $requestOptions
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function createToken($userId, array $requestOptions)
+    {
+        return $this->client->post(self::$endpoint . '/' . $userId . '/tokens', $requestOptions);
+    }
+
+    /**
+     * @param $userId
+     * @param $requestOptions
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getTokens($userId, array $requestOptions)
+    {
+        return $this->client->get(self::$endpoint . '/' . $userId . '/tokens', $requestOptions);
+    }
+
+    /**
+     * @param $tokenId
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getToken($tokenId)
+    {
+        return $this->client->get(self::$endpoint . '/tokens/' . $tokenId);
+    }
+
+    /**
+     * @param $requestOptions
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function revokeToken(array $requestOptions)
+    {
+        return $this->client->post(self::$endpoint . '/users/tokens/revoke', $requestOptions);
+    }
 }


### PR DESCRIPTION
Hi. It seems that v4.1 of the mattermost platform is due for release around 16th August. This pull request is to add 4 new endpoints which are documented in the API docs as being available in v4.1.
(There were two more related to ElasticSearch, but I haven't done anything with them).

This is completely untested :)