### PR TITLE
Add ability to save a new reaction

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -247,8 +247,16 @@ class Driver
     /**
      * @return EmojiModel
      */
-    public function getEmojiModelModel()
+    public function getEmojiModel()
     {
         return $this->getModel(EmojiModel::class);
+    }
+
+    /**
+     * @return ReactionModel
+     */
+    public function getReactionModel()
+    {
+        return $this->getModel(ReactionModel::class);
     }
 }

--- a/src/Models/ReactionModel.php
+++ b/src/Models/ReactionModel.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This Driver is based entirely on official documentation of the Mattermost Web
+ * Services API and you can extend it by following the directives of the documentation.
+ *
+ * For the full copyright and license information, please read the LICENSE.txt
+ * file that was distributed with this source code. For the full list of
+ * contributors, visit https://github.com/gnello/php-mattermost-driver/contributors
+ *
+ * God bless this mess.
+ *
+ * @author Bruno Spyckerelle <bruno@spyckerelle.fr>
+ * @link https://api.mattermost.com/
+ */
+
+namespace Gnello\Mattermost\Models;
+
+/**
+ * Class ReactionModel
+ *
+ * @package Gnello\Mattermost\Models
+ */
+class ReactionModel extends AbstractModel
+{
+    /**
+     * @var string
+     */
+    public static $endpoint = '/reactions';
+
+    /**
+     * @param array $requestOptions
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function saveReaction(array $requestOptions)
+    {
+        return $this->client->post(self::$endpoint, $requestOptions);
+    }
+}


### PR DESCRIPTION
Despite lack of documentation, Mattermost API offers the possibility to save a reaction to a Post : https://github.com/mattermost/mattermost-server/blob/master/api4/reaction.go