### PR TITLE
Fixed Channel Create endpoint for API v4

### DIFF
--- a/src/Models/ChannelModel.php
+++ b/src/Models/ChannelModel.php
@@ -33,7 +33,7 @@ class ChannelModel extends AbstractModel
      */
     public function createChannel(array $requestOptions)
     {
-        return $this->client->post(self::$endpoint . '/create', $requestOptions);
+        return $this->client->post(self::$endpoint, $requestOptions);
     }
 
     /**


### PR DESCRIPTION
Updated channelCreate method to match current v4 API documentation: https://api.mattermost.com/#tag/channels%2Fpaths%2F~1channels%2Fpost