### PR TITLE
Removed extra slash in getUsersByUsernames

### DIFF
--- a/src/Models/UserModel.php
+++ b/src/Models/UserModel.php
@@ -217,7 +217,7 @@ class UserModel extends AbstractModel
      */
     public function getUsersByUsernames(array $requestOptions)
     {
-        return $this->client->post(self::$endpoint . '/usernames/', $requestOptions);
+        return $this->client->post(self::$endpoint . '/usernames', $requestOptions);
     }
 
     /**


### PR DESCRIPTION
Extra slash in getUsersByUsernames endpoint was causing Mattermost to return "There doesn't appear to be an api call for the url='/api/v4/users/usernames/'.  Typo?".